### PR TITLE
Get horizontalVertical plugin to run on nested rules

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -68,7 +68,7 @@ function setClassNamesForStyle(
       key = `&.${modeClassName}`;
     }
 
-    if (value instanceof Object && !Array.isArray(value)) {
+    if (typeof value === 'object' && !Array.isArray(value)) {
       newStyle[key] = setClassNamesForStyle(newKeys, value as StyleRule, classNamesForModes);
     } else {
       newStyle[key] = value;

--- a/src/libs/cssTextForStyles.ts
+++ b/src/libs/cssTextForStyles.ts
@@ -14,7 +14,7 @@ interface ValueAndPath {
 export default function cssTextForStyles(styles: StyleDeclaration): string[] {
   const valueAndPaths: ValueAndPath[] = [];
   _.forEach(styles, (style, key: string) => {
-    if (!(style instanceof Object)) {
+    if (typeof style !== 'object') {
       throw new Error(`No CSS selector provided, just property ${key} with value ${JSON.stringify(style)}`);
     }
     style = applyPlugins(style);
@@ -33,7 +33,7 @@ function valueAndPathForStyle(style: StyleRule, keys: string[]) {
 
     const path = keys.concat(key);
 
-    if (value instanceof Object && !Array.isArray(value)) {
+    if (typeof value === 'object' && !Array.isArray(value)) {
       valueAndPaths.push(...valueAndPathForStyle(value as StyleRule, path));
 
     } else {

--- a/src/plugins/horizontalVertical.ts
+++ b/src/plugins/horizontalVertical.ts
@@ -1,8 +1,11 @@
 import { StyleRule } from '../types';
 
-export default function horizontalVertical(style: StyleRule) {
+export default function horizontalVertical(style: StyleRule): StyleRule {
   for (const property in style) {
-    if (property === 'paddingHorizontal') {
+    const cssValue = style[property];
+    if (cssValue instanceof Object && !Array.isArray(cssValue)) {
+      style[property] = horizontalVertical(cssValue as StyleRule);
+    } else if (property === 'paddingHorizontal') {
       style['paddingLeft'] = style[property];
       style['paddingRight'] = style[property];
       delete style[property];

--- a/src/plugins/horizontalVertical.ts
+++ b/src/plugins/horizontalVertical.ts
@@ -3,7 +3,7 @@ import { StyleRule } from '../types';
 export default function horizontalVertical(style: StyleRule): StyleRule {
   for (const property in style) {
     const cssValue = style[property];
-    if (cssValue instanceof Object && !Array.isArray(cssValue)) {
+    if (typeof cssValue === 'object' && !Array.isArray(cssValue)) {
       style[property] = horizontalVertical(cssValue as StyleRule);
     } else if (property === 'paddingHorizontal') {
       style['paddingLeft'] = style[property];

--- a/src/plugins/unit.ts
+++ b/src/plugins/unit.ts
@@ -9,7 +9,7 @@ export default function addUnit(style: StyleRule, unit = 'px') {
     const cssValue = style[property];
     if (Array.isArray(cssValue)) {
       style[property] = cssValue.map(val => addUnitIfNeeded(val, unit));
-    } else if (cssValue instanceof Object) {
+    } else if (typeof cssValue === 'object') {
       style[property] = addUnit(cssValue as StyleRule, unit);
     } else {
       style[property] = addUnitIfNeeded(cssValue, unit);

--- a/test/unit/compile.ts
+++ b/test/unit/compile.ts
@@ -64,6 +64,25 @@ describe(`compile`, () => {
       `}`]);
   });
 
+  it(`applies plugins deeply`, () => {
+    const className = compile({
+      root: {
+        blah: {
+          flex:1,
+          margin: 5,
+          paddingHorizontal: 4,
+        },
+      },
+    });
+    expect(className).to.deep.equal({root: 'dapper-root-a'});
+    expect(renderCSSTextStub).to.have.been.calledWith([
+      `.dapper-root-a blah{` +
+        `-webkit-flex:1;-ms-flex:1;flex:1;` +
+        `margin:5px;` +
+        `padding-left:4px;padding-right:4px` +
+      `}`]);
+  });
+
   it(`handles pseudo tags`, () => {
     const className = compile({
       root: {


### PR DESCRIPTION
In response to https://github.com/convoyinc/dapper/issues/16

Its not clear how to abstract out the 
```
if (cssValue instanceof Object && !Array.isArray(cssValue)) {
      style[property] = recurse(cssValue as StyleRule);
```
because prefixer requires getting passed the entire rule. I could add a helper wrapper which just calls the plugin on a specific property and value, but then it has to have some kind of interface that lets it delete that property and replace it with a new one which gets complicated. I think its relatively easy for the plugin author for now to simply just know to recurse through Objects.