### PR TITLE
Compute w/o compile of declaration when no modes

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -4,14 +4,22 @@ import {
   CompiledStyleSheet,
   ComputedStyleSheet,
   ModeDeclarations,
+  StyleDeclaration,
 } from './types';
+import compile from './compile';
 
 export default function compute<TKeys extends string, State>(
-  compiledStyles: CompiledStyleSheet<TKeys>,
-  modeDeclarations: ModeDeclarations<State>,
-  state: State,
+  compiledStyles: CompiledStyleSheet<TKeys>|StyleDeclaration<TKeys>,
+  modeDeclarations?: ModeDeclarations<State>,
+  state?: State,
 ): ComputedStyleSheet<TKeys> {
-  const modes = _.mapValues(modeDeclarations, resolver => resolver(state));
+  if (!modeDeclarations && !state) {
+    compiledStyles = compile(compiledStyles as StyleDeclaration<TKeys>);
+  } else if (!modeDeclarations || !state) {
+    throw new Error('Must provide modeDeclarations and state or neither of them');
+  }
+
+  const modes = _.mapValues(modeDeclarations as ModeDeclarations<State>, resolver => resolver(state as State));
 
   return _.mapValues(compiledStyles, (style: CompiledStyle) => {
     if (typeof style === 'string') {


### PR DESCRIPTION
Allows the following:

```
const STYLES = dapper.compute({
  root: {
    color: 'red',
  },
});
```