### PR TITLE
Fix process.env.NODE_ENV to actually get replaced

### DIFF
--- a/src/configure.ts
+++ b/src/configure.ts
@@ -8,9 +8,9 @@ export interface Configuration {
 
 export let config: Configuration = Object.freeze({
   node: null,
-  classNamePrefix: _.get(process, 'env.NODE_ENV') === 'production' ? 'd-' : 'dapper-',
-  friendlyClassNames: _.get(process, 'env.NODE_ENV') !== 'production',
-  useInsertRule: _.get(process, 'env.NODE_ENV') === 'production',
+  classNamePrefix: process.env.NODE_ENV === 'production' ? 'd-' : 'dapper-',
+  friendlyClassNames: process.env.NODE_ENV !== 'production',
+  useInsertRule: process.env.NODE_ENV === 'production',
 });
 
 export default function configure(cfg: Partial<Configuration>) {

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 export interface Configuration {
   node: HTMLStyleElement|null;
   classNamePrefix: string;


### PR DESCRIPTION
Webpack's DefinePlugin does a direct replacement of strings it finds. It needs to find `process.env.NODE_ENV`, it doesn't actually define the object. This meant that the configuration of dapper was to not use stylesheet.insertRule, and instead kept doing string manipulation `node.textContent += cssTexts.join('\n') + '\n';`. Turns out that's pretty slow in production and been causing major evaluation time increases
  