### PR TITLE
Support node environments

### DIFF
--- a/src/libs/renderCSSText.ts
+++ b/src/libs/renderCSSText.ts
@@ -1,6 +1,8 @@
 import configure, { Configuration } from '../configure';
 
 export default function renderCSSText(cssTexts: string[], config: Configuration) {
+  if (typeof document === 'undefined') return;
+
   let node = config.node;
   if (!node) {
     node = document.createElement('style');


### PR DESCRIPTION
There is no document in Node environments, unless using JSDOM. This enables use in test/ssr/prerender environments without errors.