### PR TITLE
Fix type checking

### DIFF
--- a/src/libs/cssTextForStyles.ts
+++ b/src/libs/cssTextForStyles.ts
@@ -6,7 +6,7 @@ import { StyleRule, StyleDeclaration } from '../types';
 
 interface ValueAndPath {
   path: string[];
-  value: string|number;
+  value: string|number|undefined;
 }
 
 const CSS_PROPERTY_REGEX = /^-?[_a-z][_a-z0-9-]*$/i;

--- a/src/libs/generateCSSDeclaration.ts
+++ b/src/libs/generateCSSDeclaration.ts
@@ -1,5 +1,6 @@
 import * as hyphenateStyleName from 'hyphenate-style-name';
 
-export default function generateCSSDeclaration(property: string, value: string|number) {
+export default function generateCSSDeclaration(property: string, value: string|number|undefined) {
+  if (value === undefined) return '';
   return `${hyphenateStyleName(property)}:${value}`;
 }

--- a/src/plugins/unit.ts
+++ b/src/plugins/unit.ts
@@ -8,7 +8,7 @@ export default function addUnit(style: StyleRule, unit = 'px') {
 
     const cssValue = style[property];
     if (Array.isArray(cssValue)) {
-      style[property] = cssValue.map(val => addUnitIfNeeded(val, unit));
+      style[property] = cssValue.map(val => addUnitIfNeeded(val, unit) as string | number);
     } else if (typeof cssValue === 'object') {
       style[property] = addUnit(cssValue as StyleRule, unit);
     } else {
@@ -19,7 +19,7 @@ export default function addUnit(style: StyleRule, unit = 'px') {
   return style;
 }
 
-function addUnitIfNeeded(value: string|number, unit: string) {
+function addUnitIfNeeded(value: string|number|undefined, unit: string) {
   if (typeof value === 'number') {
     return value + unit;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type StyleValue = number|string;
  * An individual style rule, containing CSS property declarations (with JS-style
  * property names), as well as other nested rules.
  */
-export type StyleRule = {[key: string]: StyleValue|StyleValue[]|StyleRule};
+export type StyleRule = { [key: string]: StyleValue | StyleValue[] | StyleRule | undefined };
 
 /**
  * A collection of style rules represented by JavaScript Objects, which are


### PR DESCRIPTION
Fixes a bug we see in chalupa-web

```
Type '{ fontFamily: string; fontSize: number; lineHeight: string; textRendering?: string | undefined; WebkitFontSmoothing?: string | undefined; }' is not assignable to type 'string | number | StyleRule | StyleValue[]'.
  Type '{ fontFamily: string; fontSize: number; lineHeight: string; textRendering?: string | undefined; WebkitFontSmoothing?: string | undefined; }' is not assignable to type 'string'.
```
